### PR TITLE
Put types in exports for modern TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "require": "./dist/cjs/index.js"
       },
       "require": "./dist/cjs/index.js",
-      "node": "./dist/cjs/index.js"
+      "node": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Revitalizing an old project, I'm now getting this error with this package:

```
error TS7016: Could not find a declaration file for module '@soorria/solid-dropzone'. [...]
  There are types at '.../node_modules/@soorria/solid-dropzone/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@soorria/solid-dropzone' library may need to update its package.json or typings.
```

I think this might be the result of some TypeScript updates? Manually editing `node_modules/@soorria/solid-dropzone/package.json` according to this PR fixed the issue with me.